### PR TITLE
add homepage key in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "repository": "git@github.com:kettanaito/page-with.git",
+  "homepage": "https://github.com/kettanaito/page-with#readme",
   "author": "Artem Zakharchenko <kettanaito@gmail.com>",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
Hey,

somehow the package on npmjs.com (https://www.npmjs.com/package/page-with) currently doesn't like to this GitHub page. This change should fix that.