### PR TITLE
fix: listen on 127.0.0.1 as default host

### DIFF
--- a/src/server/PreviewServer.ts
+++ b/src/server/PreviewServer.ts
@@ -103,7 +103,7 @@ export class PreviewServer {
 
   public async listen(
     port = 0,
-    host = 'localhost',
+    host = '127.0.0.1',
   ): Promise<ServerConnectionInfo> {
     return new Promise((resolve, reject) => {
       this.log('establishing server connection...')


### PR DESCRIPTION
Changes the default host to the IPv4 address `127.0.0.1` to avoid issues with resolving `localhost` starting on Node v17.0.0.

Pretty much the same issue as described here: https://github.com/mswjs/interceptors/pull/215